### PR TITLE
change the autoscale target CPU utilization from 10% to 20%

### DIFF
--- a/user/Private Instances/gce_agents.md
+++ b/user/Private Instances/gce_agents.md
@@ -21,7 +21,7 @@ After a few seconds the script will complete and there will be an instance templ
 
 ## Auto-Scaling
 
-The linux agents auto-scale well for bulk testing using a [Managed Instance group](https://cloud.google.com/compute/docs/instance-groups/).  In that mode it is recommended to use preemptable instances and set a target CPU utilization to 10% (for n1-standard-2 instances) and with a cool-down period of 600 seconds.  One instance will need to be running in each region at all times and it will scale up as needed when running tests.
+The linux agents auto-scale well for bulk testing using a [Managed Instance group](https://cloud.google.com/compute/docs/instance-groups/).  In that mode it is recommended to use preemptable instances and set a target CPU utilization to 20% (for n1-standard-2 instances) and with a cool-down period of 600 seconds.  One instance will need to be running in each region at all times and it will scale up as needed when running tests.
 
 The instances take a few minutes to connect to the server after launching because they install all of the latest OS and browser updates and reboot before starting to process work.
 


### PR DESCRIPTION
I have set-up agents on GCP, and saw the instances increase randomly even if I don't use them.

See the chart here. I changed the threshold for CPU utilization from 10% to 20% on Nov 29 (changed the maximum number of instances from 5 to 10 at the same time, but it doesn't matter here), and the random increase of the number of instances no longer occurs unless I use them (each spike is the use of them).

<img width="935" alt="Screen Shot 2019-12-12 at 11 25 21" src="https://user-images.githubusercontent.com/101800/70677295-205e9200-1cd2-11ea-95df-111aa4137135.png">
