### PR TITLE
Restore arguments visibility

### DIFF
--- a/src/scripting.md
+++ b/src/scripting.md
@@ -27,7 +27,7 @@ Can be identified by innerText=Delete. The matching is case sensitive and matche
 
 In order to suppress intermediate steps you need to make sure that data logging is disabled for the steps up to the ones you want to record. For example:
 
-```text
+```markup
 logData    0
 
 // put any urls you want to navigate
@@ -44,7 +44,7 @@ The script above will navigate to the main aol portal, then to the news page and
 
 Another significant use case is if you want to test a site that requires authentication. Here is what an authentication script would look like:
 
-```text
+```markup
 logData	0
 
 // bring up the login screen
@@ -68,7 +68,7 @@ You won't get a lot of feedback as to why a script failed. For debugging purpose
 Navigates the browser to the provided URL and waits for it to complete.
 Browser Support: IE, Chrome, Firefox, Safari
 
-```text
+```markup
 usage: navigate	<url>
 example: navigate	http://webmail.aol.com
 
@@ -78,7 +78,7 @@ example: navigate	http://webmail.aol.com
 #### click
 Triggers a click event for the identified DOM element. This version does not have an implied wait and the script will continue running after the event is submitted (see clickAndWait for the wait version).
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: click	<attribute=value>
 example: click	title=Delete (del)
 
@@ -88,7 +88,7 @@ example: click	title=Delete (del)
 #### clickAndWait
 Triggers a click event for the identified DOM element and subsequently waits for browser activity to complete.
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: clickAndWait	<attribute=value>
 example: clickAndWait	innerText=Send
 
@@ -98,7 +98,7 @@ example: clickAndWait	innerText=Send
 #### selectValue
 Selects a value from a dropdown list of the given DOM element.
 Browser Support: IE
-```text
+```markup
 usage: selectValue	<attribute=value>	<value>
 example: selectValue	id=country	usa
 
@@ -109,7 +109,7 @@ example: selectValue	id=country	usa
 #### sendClick / sendClickAndWait
 Creates a javascript OnClick event and sends it to the indicated element.
 Browser Support: IE
-```text
+```markup
 usage: sendClickAndWait	<attribute=value>
 example: sendClickAndWait	innerText=Send
 
@@ -119,7 +119,7 @@ example: sendClickAndWait	innerText=Send
 #### sendKeyDown / sendKeyUp / sendKeyPress (AndWait)
 Creates a javascript keyboard event (OnKeyDown, OnKeyUp, OnKeyPress) and sends it to the indicated element.
 Browser Support: IE
-```text
+```markup
 usage: sendKeyDownAndWait	<attribute=value>    <key>
 example: sendKeyDownAndWait	name=user    x
 
@@ -130,7 +130,7 @@ example: sendKeyDownAndWait	name=user    x
 #### setInnerHTML
 Sets the innerHTML of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you want to include HTML formatting.
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: setInnerHTML	<attribute=value>	<value>
 example: setInnerHTML	contentEditable'true	%MSG%
 
@@ -141,7 +141,7 @@ example: setInnerHTML	contentEditable'true	%MSG%
 #### setInnerText
 Sets the innerText of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you don't want to include any HTML formatting.
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: setInnerText	<attribute=value>	<value>
 example: setInnerText	contentEditable'true	%MSG%
 
@@ -152,7 +152,7 @@ example: setInnerText	contentEditable'true	%MSG%
 #### setValue
 Sets the value attribute of the given DOM element to the provided value. This is usually used for filling in text elements on a page (forms or otherwise). Currently only "input" and "textArea" element types are supported.
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: setValue	<attribute=value>	<value>
 example: setValue	name=loginId	userName
 
@@ -163,7 +163,7 @@ example: setValue	name=loginId	userName
 #### submitForm
 Triggers a submit event for the identified form.
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: submitForm	<attribute=value>
 example: submitForm	name=AOLLoginForm
 
@@ -173,7 +173,7 @@ example: submitForm	name=AOLLoginForm
 #### exec
 Executes javascript.
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: exec	<javascript code>
 example: exec	window.setInterval('window.scrollBy(0,600)', 1000);
 ```
@@ -181,7 +181,7 @@ example: exec	window.setInterval('window.scrollBy(0,600)', 1000);
 #### execAndWait
 Executes javascript and waits for the browser to complete any activity generated from the action.
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: execAndWait	<javascript code>
 example: execAndWait	window.setInterval('window.scrollBy(0,600)', 1000);
 ```
@@ -194,7 +194,7 @@ Sets the "Activity Based Measurement" mode. The valid values are:
 * 1 - Enabled (Web 2.0 - Measure until activity stops)
 The default if not specified in the script is 1 (Enabled)
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: setABM	<mode>
 example: setABM	0
 
@@ -204,7 +204,7 @@ example: setABM	0
 #### setActivityTimeout
 Overrides the timeout value for the time after the last network activity before a test is considered complete (defaults to 2000 which is 2 seconds).
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage: setActivityTimeout	<timeout in milliseconds>
 example: setActivityTimeout	5000
 
@@ -214,7 +214,7 @@ example: setActivityTimeout	5000
 #### setTimeout
 Overrides the timeout value for the individual script steps.
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage: setTimeout	<timeout in seconds>
 example: setTimeout	240
 
@@ -225,7 +225,7 @@ example: setTimeout	240
 #### block
 Blocks individual requests from loading (useful for blocking content like ads). The command matches the list of things to block against the full url of each request (including host name).
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: block    <block strings>
 example: block    adswrapper.js addthis.com
 
@@ -245,7 +245,7 @@ example: blockDomains    adswrapper.js addthis.com
 #### blockDomainsExcept
 Blocks all requests not from one of the given domains from loading (useful for blocking content like ads). Takes a space-delimited list of full domains to allow.
 Browser Support: Desktop (wptdriver 300+)
-```text
+```markup
 usage: blockDomainsExcept    <allow domains>
 example: blockDomainsExcept    www.example.com cdn.example.com
 
@@ -255,7 +255,7 @@ example: blockDomainsExcept    www.example.com cdn.example.com
 #### setCookie
 Stores a browser cookie to be used while navigating.
 Browser Support: IE, Chrome, Firefox
-```text
+```markup
 usage: setCookie	<path>	<value>
 example: setCookie	http://www.aol.com	zip=20166
 example: setCookie	http://www.aol.com	TestData = Test; expires = Sat,01-Jan-2000 00:00:00 GMT
@@ -267,7 +267,7 @@ example: setCookie	http://www.aol.com	TestData = Test; expires = Sat,01-Jan-2000
 #### setDns
 Allows for overriding the IP address to be used for a host name. The override is effectively the same as populating an entry in the hosts file and will eliminate the DNS lookup times.
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage: setDns	<host name>	<IP Address>
 example: setDns	www.aol.com	127.0.0.1
 
@@ -278,7 +278,7 @@ example: setDns	www.aol.com	127.0.0.1
 #### setDNSName
 Allows for overriding a host name (creating a fake CNAME).
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage: setDnsName	<name to override>	<real name>
 example: setDnsName	pat.aol.com	www.aol.com
 
@@ -291,7 +291,7 @@ Overrides the User Agent string sent by the browser
 Browser Support: IE, Chrome, Firefox, Safari
 
 CAUTION : You will still be using the same browser engine so you are still limited by the capabilities and behavior of that browser even if you are spoofing another browser
-```text
+```markup
 usage: setUserAgent    <user agent string>
 example: setUserAgent    Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543 Safari/419.3
 
@@ -301,7 +301,7 @@ example: setUserAgent    Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWeb
 #### overrideHost
 Replaces the value of the Host: HTTP header for the given host with the provided replacement.  It also adds a new header (x-Host:) with the original value.
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
-```text
+```markup
 usage: overrideHost	<host>    <new host>
 example: overrideHost	www.aol.com    www.notaol.com
 
@@ -312,7 +312,7 @@ example: overrideHost	www.aol.com    www.notaol.com
 #### overrideHostUrl
 For all requests to the given host, rewrite the requests to go to a different server and include the original host in the new URI.
 Browser Support: IE
-```text
+```markup
 usage: overrideHostUrl	<host>    <new host>
 example: overrideHostUrl	www.webpagetest.org    staging.webpagetest.org
 
@@ -324,7 +324,7 @@ In this example, http://www.webpagetest.org/index.php will get rewritten to actu
 #### addHeader
 Adds the specified header to every http request (in addition to the headers that exist, does not overwrite an existing header).
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
-```text
+```markup
 usage: addHeader	<header>    {filter}
 example: addHeader	Pragma: akamai-x-cache-on
 
@@ -335,7 +335,7 @@ example: addHeader	Pragma: akamai-x-cache-on
 #### setHeader
 Adds the specified header to every http request, overriding the header if it already exists.
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
-```text
+```markup
 usage: setHeader	<header>    {filter}
 example: setHeader	UA-CPU: none-ya
 
@@ -346,7 +346,7 @@ example: setHeader	UA-CPU: none-ya
 #### resetHeaders
 Clears any headers that were specified through addHeaders or setHeaders (in case you want to only override headers for part of a script).
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage: resetHeaders
 example: resetHeaders
 ```
@@ -356,7 +356,7 @@ example: resetHeaders
 #### combineSteps
 Causes multiple script steps to be combined into a single "step" in the results
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage: combineSteps	[count]
 example: combineSteps
 
@@ -372,7 +372,7 @@ navigate	www.aol.com
 #### if/else/endif
 Conditionally execute a block of script code based on run number or cached state for the test.  Conditional blocks can be nested.
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage:  if	[cached|run]    <value>
         else
         endif
@@ -392,7 +392,7 @@ example:    if    run    1
 #### expireCache
 Expires any cache entries that will expire within the specified number of seconds.  This can be used to simulate a repeat view after a certain amount of time (for example, what it would be like to browse the page the next day).  It doesn't help with simulating content changes but any resources with a short expiration will end up being checked with if-modified-since requests.
 Browser Support: IE
-```text
+```markup
 usage: expireCache	<seconds>
 example: expireCache	86400
 
@@ -402,7 +402,7 @@ example: expireCache	86400
 #### firefoxPref
 Allows you to specify arbitrary preferences that will be configured before launching the browser.
 Browser Support: Firefox
-```text
+```markup
 usage: firefoxPref	<pref>    <value>
 examples:
 firefoxPref    network.http.pipelining    false
@@ -416,7 +416,7 @@ firefoxPref    general.useragent.override    "Some User Agent String"
 #### setEventName
 Sets the name of the event for the next measurable operation. It is important to only set this right before the action that will generate the activity you want to measure so that you don't inadvertently measure other page activity. Without explicit event names each step will be automatically named Step_1, Step_2, etc.
 Browser Support: IE
-```text
+```markup
 usage: setEventName	<event name>
 example: setEventName	loadWebmail
 
@@ -426,7 +426,7 @@ example: setEventName	loadWebmail
 #### setLocation
 Specifies a geolocation override position.
 Browser Support: Chrome
-```text
+```markup
 usage: setLocation	<lat>,<lng>    <accuracy>
 example: setLocation    38.954980,-77.447956    10
 
@@ -438,7 +438,7 @@ example: setLocation    38.954980,-77.447956    10
 #### setViewportSize
 Changes the size of the visible browser window so that the page viewport matches the given dimensions.  If you get black areas on your screen shots then the viewport is larger than the desktop.
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage: setViewportSize	<width>    <height>
 example: setViewportSize    320    365
 
@@ -449,7 +449,7 @@ example: setViewportSize    320    365
 #### sleep
 Pauses the script operation for a given number of seconds.
 Browser Support: IE, Chrome, Firefox, Safari
-```text
+```markup
 usage: sleep	<seconds to sleep>
 example: sleep	5
 
@@ -458,7 +458,7 @@ example: sleep	5
 
 ## Sample scripts
 ### Mail test
-```text
+```markup
 // load the account name and password
 // bring up the login screen
 setEventName	launch
@@ -511,7 +511,7 @@ clickAndWait	className=signOutLink
 ```
 
 ### MyAOL Authenticated profile
-```text
+```markup
 // bring up the login screen
 setDOMElement	name=loginId
 navigate	https://my.screenname.aol.com/_cqr/login/login.psp?mcState=initialized&sitedomain=my.aol.com&authLev=0&siteState=OrigUrl%3Dhttp%3A%2F%2Fmy.aol.com%2F
@@ -530,7 +530,7 @@ This script will:
 * Force www.aol.com to resolve to 127.0.0.1
 * Set a "zip" cookie on the www.aol.com domain
 * Navigate and measure the time to load www.aol.com
-```text
+```markup
 setDnsName	www1.aol.com	www.aol.com
 setDns	www.aol.com	127.0.0.1
 setCookie	http://www.aol.com	zip=20166
@@ -543,7 +543,7 @@ This script will:
 * Use the iPhone user agent string
 * Change the browser dimensions to match the iPhone
 * Navigate to www.aol.com
-```text
+```markup
 setUserAgent	Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25
 setViewportSize    320    356
 navigate	http://www.aol.com


### PR DESCRIPTION
https://github.com/WPO-Foundation/webpagetest-docs/commit/b88629a10e01bbe9f9c5115252f6b40cc3b76085 hid them by not escaping the angle brackets anymore

I've chosen `markup` as it seem the most "neutral" language but it highlights the arguments without a `=` differently. There might be a better way to escape angle brackets (besides doing it manually in the markdown).