### PR TITLE
Document variable substitutions for scripting

### DIFF
--- a/src/scripting.md
+++ b/src/scripting.md
@@ -96,7 +96,12 @@ output: setHeader Foo: Bar  wpt\.example
 
 ### %HOSTR%
 
-🤷
+Same as %HOST% but uses the final host name of the test URL after following any redirects.
+
+```markup
+URL: https://redirect.wpt.example
+input: setDnsName %HOSTR% dns.example
+output: setDnsName  wpt.example dns.example
 
 
 ## Command Reference

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -103,7 +103,6 @@ URL: https://redirect.wpt.example
 input: setDnsName %HOSTR% dns.example
 output: setDnsName  wpt.example dns.example
 
-
 ## Command Reference
 
 ### Navigation/DOM Interaction

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -60,6 +60,45 @@ submitForm	name=AOLLoginForm
 
 You won't get a lot of feedback as to why a script failed. For debugging purposes it is easiest to limit scripts to navigate and exec/execAndWait commands which can be debugged locally in a browser's dev tools.
 
+## Variable substitutions
+
+Some variables are replaced based on the URL provided for the test.
+
+### %URL%
+
+URL provided for the test.
+
+```markup
+URL: https://wpt.example
+input: navigate %URL%
+output: navigate  https://wpt.example
+```
+
+### %HOST%
+
+This will be the Host of the URL provided for the test. This does not include the protocol.
+
+```markup
+URL: https://wpt.example
+input: setDnsName %HOST% dns.example
+output: setDnsName  wpt.example dns.example
+```
+
+### %HOST_REGEX%
+
+Same as %HOST% but with dots escaped to make it suitable for use in regular expressions.
+
+```markup
+URL: https://wpt.example
+input: setHeader  Foo: Bar  %HOST_REGEX%
+output: setHeader Foo: Bar  wpt\.example
+```
+
+### %HOSTR%
+
+🤷
+
+
 ## Command Reference
 
 ### Navigation/DOM Interaction


### PR DESCRIPTION
This is based on my reading of [runtest.php](https://github.com/WPO-Foundation/webpagetest/blob/63f7d3be55f03666a790d36a0b45ccb75fe6b561/www/runtest.php#L2889-L2921).

I've left `%HOSTR%` undocumented as I wasn't sure what the intention is.