### PR TITLE
Scripting: start with examples, highlight recommended commands and selectors, more

### DIFF
--- a/src/scripting.md
+++ b/src/scripting.md
@@ -683,6 +683,12 @@ example: sleep 5
 <seconds to sleep> - An integer indicating how long to sleep.  The allowable range is 1-30.
 ```
 
+## Debugging
+
+There is currently no way to debug failing WebPageTest scripts. If a script command fails, it will fail silently.
+
+To simplify script development, consider limiting yourself to [Recommended commands](#recommended-commands) only.
+
 ## Sample scripts
 ### Mail test
 ```markup

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -58,8 +58,6 @@ setValue	name=password	somepassword
 submitForm	name=AOLLoginForm
 ```
 
-You won't get a lot of feedback as to why a script failed. For debugging purposes it is easiest to limit scripts to navigate and exec/execAndWait commands which can be debugged locally in a browser's dev tools.
-
 ## Variable substitutions
 
 Some variables are replaced based on the URL provided for the test.
@@ -108,7 +106,38 @@ input: setDnsName %HOSTR% dns.example
 output: setDnsName  wpt.example dns.example
 ```
 
-## Command Reference
+## Recommended Commands
+
+For historical reasons, if a script step fails, it does so silently. If something doesn’t work, unfortunately, you won’t get any feedback why. If you’re new to scripting, we recommend using the following commands only. It’s easier to debug them as you can run them manually yourself.
+
+#### navigate
+Navigates the browser to the provided URL and waits for it to complete.
+Browser Support: IE, Chrome, Firefox, Safari
+
+```markup
+usage: navigate	<url>
+example: navigate	http://webmail.aol.com
+
+<url> - URL to provide the browser for navigation (same as you would enter into the address bar)
+```
+
+#### exec
+Executes javascript.
+Browser Support: IE, Chrome, Firefox
+```markup
+usage: exec	<javascript code>
+example: exec	window.setInterval('window.scrollBy(0,600)', 1000);
+```
+
+#### execAndWait
+Executes javascript and waits for the browser to complete any activity generated from the action.
+Browser Support: IE, Chrome, Firefox
+```markup
+usage: execAndWait	<javascript code>
+example: execAndWait	window.setInterval('window.scrollBy(0,600)', 1000);
+```
+
+## Full Command Reference
 
 ### Navigation/DOM Interaction
 

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -90,9 +90,7 @@ navigate not-a-comment.com
 
 ### Selectors
 
-Commands like [`click`](#click), [`setValue`](#setvalue), and others operate on DOM elements. To select a DOM element, use the following selectors:
-
-#### `<attribute>=<value>`
+Commands like [`click`](#click), [`setValue`](#setvalue), and others operate on DOM elements. To select a DOM element, use the `<attribute>=<value>` selector.
 
 This selector selects elements based on their HTML attributes. For the following input:
 
@@ -115,62 +113,6 @@ Example:
 ```markup
 // Set the email to darth@vader.com
 setValue type=email darth@vader.com
-```
-
-#### `innerText=<text>`
-
-This selector selects elements based on its inner text. For the following button:
-
-```html
-<button type="submit">Login</button>
-```
-
-the following selectors will work:
-
-* ✅ `innerText=Login`
-
-and the following selectors will not:
-
-* ❌ `innerText=login` (the selector is case sensitive)
-* ❌ `innerText=log` (the selector must match the full string)
-
-Also, for a different button, this will not work either:
-
-* ❌ `innerText=log in` (spaces inside the text are not supported)
-
-Example:
-
-```markup
-// Click the Login button
-click innerText=Login
-```
-
-#### `innerHtml=<html>`
-
-This selector selects elements based on its inner HTML. For the following link:
-
-```html
-<a href="/dashboard"><span>Dashboard</span></button>
-```
-
-the following selectors will work:
-
-* ✅ `innerHtml=<span>Dashboard</span>`
-
-and the following selectors will not:
-
-* ❌ `innerHtml=<span>dashboard</span>` (the selector is case sensitive)
-* ❌ `innerHtml=span` (you can’t select just on tags)
-
-Also, for a different link, this will not work either:
-
-* ❌ `innerText=<span>Open Dashboard</span>` (spaces inside the HTML are not supported)
-
-Example:
-
-```markup
-// Click the Dashboard link
-click innerHtml=<span>Dashboard</span>
 ```
 
 ### Variable substitutions

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -397,8 +397,10 @@ example: execAndWait window.setInterval('window.scrollBy(0,600)', 1000);
 Sets the "Activity Based Measurement" mode. The valid values are:
 * 0 - Disabled (Web 1.0 - Measure based off of document complete)
 * 1 - Enabled (Web 2.0 - Measure until activity stops)
-The default if not specified in the script is 1 (Enabled)
+
+The default if not specified in the script is 1 (Enabled).
 Browser Support: IE, Chrome, Firefox
+
 ```markup
 usage:   setABM <mode>
 example: setABM 0

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -62,18 +62,18 @@ example: navigate http://webmail.aol.com
 ```
 
 #### `exec`
-Executes javascript.
+Executes JavaScript.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage:   exec <javascript code>
+usage:   exec <JavaScript code>
 example: exec window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
 #### `execAndWait`
-Executes javascript and waits for the browser to complete any activity generated from the action.
+Executes JavaScript and waits for the browser to complete any activity generated from the action.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage:   execAndWait <javascript code>
+usage:   execAndWait <JavaScript code>
 example: execAndWait window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
@@ -272,7 +272,7 @@ example: selectValue id=country usa
 For the list of supported selectors, see [Selectors](#selectors).
 
 #### `sendClick` / `sendClickAndWait`
-Creates a javascript `onclick` event and sends it to the indicated element.
+Creates a JavaScript `onclick` event and sends it to the indicated element.
 Browser Support: IE
 ```markup
 usage:   sendClickAndWait <wpt-selector>
@@ -310,7 +310,7 @@ example: keypress Enter
 For the difference between `keypress` and `keypressAndWait`, see [`click`](#click) and [`clickAndWait`](#clickandwait).
 
 #### `sendKeyDown` / `sendKeyUp` / `sendKeyPress` (`sendKeyDownAndWait` / `sendKeyUpAndWait` / `sendKeyPressAndWait`)
-Creates a javascript keyboard event (`onkeydown`, `onkeyup`, `onkeypress`) and sends it to the indicated element.
+Creates a JavaScript keyboard event (`onkeydown`, `onkeyup`, `onkeypress`) and sends it to the indicated element.
 Browser Support: IE
 ```markup
 usage:   sendKeyDownAndWait <wpt-selector> <key>
@@ -376,18 +376,18 @@ example: submitForm name=AOLLoginForm
 For the list of supported selectors, see [Selectors](#selectors).
 
 #### `exec`
-Executes javascript.
+Executes JavaScript.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage:   exec <javascript code>
+usage:   exec <JavaScript code>
 example: exec window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
 #### `execAndWait`
-Executes javascript and waits for the browser to complete any activity generated from the action.
+Executes JavaScript and waits for the browser to complete any activity generated from the action.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage:   execAndWait <javascript code>
+usage:   execAndWait <JavaScript code>
 example: execAndWait window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
@@ -429,10 +429,10 @@ example: setTimeout 240
 #### `waitFor`
 Poll the page waiting for the supplied script to evaluate to true. Must be set before the navigation step that is to be measured and persists until cleared (by providing an empty script).
 ```markup
-usage:   waitFor <javascript snippet>
+usage:   waitFor <JavaScript snippet>
 example: waitFor document.getElementById('results-with-statistics') && document.getElementById('results-with-statistics').innerText.length > 0
 
-<javascript snippet> - Code to evaluate periodically to test for complete. Should evaluate to true when the step is to stop.
+<JavaScript snippet> - Code to evaluate periodically to test for complete. Should evaluate to true when the step is to stop.
 ```
 
 #### `waitInterval`

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -48,7 +48,7 @@ See more [commands](#recommended-commands) and [examples](#sample-scripts) below
 
 ## Recommended Commands
 
-For historical reasons, if a script step fails, it does so silently. If something doesn’t work, unfortunately, you won’t get any feedback why. If you’re new to scripting, we recommend using the following commands only. It’s easier to debug them as you can run them manually yourself.
+For historical reasons, if a script step fails, it does so silently. If something doesn’t work, unfortunately, you won’t get any feedback why. If you’re new to scripting, we recommend using the following commands only. It’s easier to debug them as you can run them manually in the browser.
 
 #### `navigate`
 Navigates the browser to the provided URL and waits for it to complete.
@@ -758,7 +758,7 @@ setDOMElement className=more_pics
 submitForm name=AOLLoginForm
 ```
 
-#### DNS Override
+### DNS Override
 This script will:
 
 * Create a fake DNS entry for www1.aol.com and have it lookup www.aol.com instead
@@ -772,7 +772,7 @@ setCookie http://www.aol.com zip=20166
 navigate http://www.aol.com
 ```
 
-#### iPhone Spoofing
+### iPhone Spoofing
 This script will:
 
 * Use the iPhone user agent string

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -605,9 +605,10 @@ example: expireCache 86400
 
 #### `clearCache`
 Clears all cache and cookies.
+Browser Support: Chrome, Safari on iOS
 
 ```markup
-usage:   clearCache <seconds>
+usage:   clearCache
 example: clearCache
 ```
 

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -46,54 +46,6 @@ execAndWait document.querySelector('.chat-dialog > button').click()
 
 See more [commands](#recommended-commands) and [examples](#sample-scripts) below.
 
-## Variable substitutions
-
-Some variables are replaced based on the URL provided for the test.
-
-### %URL%
-
-URL provided for the test.
-
-```markup
-URL: https://wpt.example
-input: navigate %URL%
-output: navigate  https://wpt.example
-```
-
-### %HOST%
-
-This will be the Host of the URL provided for the test. This does not include the protocol.
-
-```markup
-URL: https://wpt.example
-input: setDnsName %HOST% dns.example
-output: setDnsName  wpt.example dns.example
-```
-
-### %ORIGIN%
-
-The Origin of the URL. This includes the protocol, the host and the port (if it is defined).
-
-```markup
-URL: https://wpt.example/hello
-input: setCookie  %ORIGIN% foo=bar
-output: setCookie https://wpt.example foo=bar
-
-URL: https://wpt.example:8080/hello
-input: setCookie  %ORIGIN% foo=bar
-output: setCookie https://wpt.example:8080 foo=bar
-```
-
-### %HOSTR%
-
-Same as %HOST% but uses the final host name of the test URL after following any redirects.
-
-```markup
-URL: https://redirect.wpt.example
-input: setDnsName %HOSTR% dns.example
-output: setDnsName  wpt.example dns.example
-```
-
 ## Recommended Commands
 
 For historical reasons, if a script step fails, it does so silently. If something doesn’t work, unfortunately, you won’t get any feedback why. If you’re new to scripting, we recommend using the following commands only. It’s easier to debug them as you can run them manually yourself.
@@ -219,6 +171,54 @@ Example:
 ```markup
 // Click the Dashboard link
 click innerHtml=<span>Dashboard</span>
+```
+
+### Variable substitutions
+
+Some variables are replaced based on the URL provided for the test.
+
+#### %URL%
+
+URL provided for the test.
+
+```markup
+URL: https://wpt.example
+input: navigate %URL%
+output: navigate  https://wpt.example
+```
+
+#### %HOST%
+
+This will be the Host of the URL provided for the test. This does not include the protocol.
+
+```markup
+URL: https://wpt.example
+input: setDnsName %HOST% dns.example
+output: setDnsName  wpt.example dns.example
+```
+
+#### %ORIGIN%
+
+The Origin of the URL. This includes the protocol, the host and the port (if it is defined).
+
+```markup
+URL: https://wpt.example/hello
+input: setCookie  %ORIGIN% foo=bar
+output: setCookie https://wpt.example foo=bar
+
+URL: https://wpt.example:8080/hello
+input: setCookie  %ORIGIN% foo=bar
+output: setCookie https://wpt.example:8080 foo=bar
+```
+
+#### %HOSTR%
+
+Same as %HOST% but uses the final host name of the test URL after following any redirects.
+
+```markup
+URL: https://redirect.wpt.example
+input: setDnsName %HOSTR% dns.example
+output: setDnsName  wpt.example dns.example
 ```
 
 ### Navigation/DOM Interaction

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -593,31 +593,6 @@ navigate www.yahoo.com
 navigate www.aol.com
 ```
 
-#### `if`/`else`/`endif`
-Conditionally execute a block of script code based on run number or cached state for the test.  Conditional blocks can be nested.
-Browser Support: IE, Chrome, Firefox, Safari
-```markup
-usage:
-if [cached|run] <value>
-<commands>
-else
-<commands>
-endif
-
-example:
-if run 1
-  if cached 0
-  <do something for first view of first run>
-  endif
-else
-  <do something else for everything but first run>
-endif
-
-[cached|run] - Compare against run number or cached state
-<value> - matching run number or cached state to execute block
-<commands> - commands to run
-```
-
 #### `expireCache`
 Expires any cache entries that will expire within the specified number of seconds.  This can be used to simulate a repeat view after a certain amount of time (for example, what it would be like to browse the page the next day).  It doesn't help with simulating content changes but any resources with a short expiration will end up being checked with if-modified-since requests.
 Browser Support: IE
@@ -626,6 +601,14 @@ usage:   expireCache <seconds>
 example: expireCache 86400
 
 <seconds> - Any resources with a cache lifetime less than this amount of time will be forced to expire.
+```
+
+#### `clearCache`
+Clears all cache and cookies.
+
+```markup
+usage:   clearCache <seconds>
+example: clearCache
 ```
 
 #### `firefoxPref`

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -55,8 +55,8 @@ Navigates the browser to the provided URL and waits for it to complete.
 Browser Support: IE, Chrome, Firefox, Safari
 
 ```markup
-usage: navigate	<url>
-example: navigate	http://webmail.aol.com
+usage:   navigate <url>
+example: navigate http://webmail.aol.com
 
 <url> - URL to provide the browser for navigation (same as you would enter into the address bar)
 ```
@@ -65,16 +65,16 @@ example: navigate	http://webmail.aol.com
 Executes javascript.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: exec	<javascript code>
-example: exec	window.setInterval('window.scrollBy(0,600)', 1000);
+usage:   exec <javascript code>
+example: exec window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
 #### execAndWait
 Executes javascript and waits for the browser to complete any activity generated from the action.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: execAndWait	<javascript code>
-example: execAndWait	window.setInterval('window.scrollBy(0,600)', 1000);
+usage:   execAndWait <javascript code>
+example: execAndWait window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
 ## Full Reference
@@ -228,8 +228,8 @@ Navigates the browser to the provided URL and waits for it to complete.
 Browser Support: IE, Chrome, Firefox, Safari
 
 ```markup
-usage: navigate	<url>
-example: navigate	http://webmail.aol.com
+usage:   navigate <url>
+example: navigate http://webmail.aol.com
 
 <url> - URL to provide the browser for navigation (same as you would enter into the address bar)
 ```
@@ -238,8 +238,8 @@ example: navigate	http://webmail.aol.com
 Triggers a click event for the identified DOM element. This version does not have an implied wait and the script will continue running after the event is submitted (see [clickAndWait](#clickandwait) for the wait version).
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: click	<wpt-selector>
-example: click	title=Delete
+usage:   click <wpt-selector>
+example: click title=Delete
 
 <wpt-selector> - DOM element to click on
 ```
@@ -250,8 +250,8 @@ For the list of supported selectors, see [Selectors](#selectors).
 Triggers a click event for the identified DOM element and subsequently waits for browser activity to complete.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: clickAndWait	<wpt-selector>
-example: clickAndWait	innerText=Send
+usage:   clickAndWait <wpt-selector>
+example: clickAndWait innerText=Send
 
 <wpt-selector> - DOM element to click on
 ```
@@ -262,8 +262,8 @@ For the list of supported selectors, see [Selectors](#selectors).
 Selects a value from a dropdown list of the given DOM element.
 Browser Support: IE
 ```markup
-usage: selectValue	<wpt-selector>	<value>
-example: selectValue	id=country	usa
+usage:   selectValue <wpt-selector> <value>
+example: selectValue id=country usa
 
 <wpt-selector> - DOM element to select the value of
 <value> - value to use
@@ -275,8 +275,8 @@ For the list of supported selectors, see [Selectors](#selectors).
 Creates a javascript OnClick event and sends it to the indicated element.
 Browser Support: IE
 ```markup
-usage: sendClickAndWait	<wpt-selector>
-example: sendClickAndWait	innerText=Send
+usage:   sendClickAndWait <wpt-selector>
+example: sendClickAndWait innerText=Send
 
 <wpt-selector> - DOM element to send the click event to
 ```
@@ -289,7 +289,7 @@ For the difference between sendClick and sendClickAndWait, see [click](#click) a
 Simulate keyboard keypresses for each character in the given string.
 Browser Support: Chrome
 ```markup
-usage: type <string>
+usage:   type <string>
 example: type Hello World
 
 <string> - String of characters to type into the keyboard.
@@ -301,7 +301,7 @@ For the difference between type and typeAndWait, see [click](#click) and [clickA
 Simulate a keyboard keypress for the given key.
 Browser Support: Chrome
 ```markup
-usage: keypress <key>
+usage:   keypress <key>
 example: keypress Enter
 
 <key> - Keyboard key to simulate pressing. Full list of supported keys is [here](https://github.com/WPO-Foundation/wptagent/blob/master/internal/support/keys.json).
@@ -313,8 +313,8 @@ For the difference between keypress and keypressAndWait, see [click](#click) and
 Creates a javascript keyboard event (OnKeyDown, OnKeyUp, OnKeyPress) and sends it to the indicated element.
 Browser Support: IE
 ```markup
-usage: sendKeyDownAndWait	<wpt-selector>    <key>
-example: sendKeyDownAndWait	name=user    x
+usage:   sendKeyDownAndWait <wpt-selector> <key>
+example: sendKeyDownAndWait name=user x
 
 <wpt-selector> - DOM element to send the click event to
 <key> - Key command to send (special values are ENTER, DEL, DELETE, BACKSPACE, TAB, ESCAPE, PAGEUP, PAGEDOWN)
@@ -328,8 +328,8 @@ For the difference between command and commandAndWait versions, see [click](#cli
 Sets the innerHTML of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you want to include HTML formatting.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: setInnerHTML	<wpt-selector>	<value>
-example: setInnerHTML	contentEditable'true	%MSG%
+usage:   setInnerHTML <wpt-selector> <value>
+example: setInnerHTML contentEditable'true %MSG%
 
 <wpt-selector> - DOM element to set the innerText of
 <value> - value to use
@@ -341,8 +341,8 @@ For the list of supported selectors, see [Selectors](#selectors).
 Sets the innerText of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you don't want to include any HTML formatting.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: setInnerText	<wpt-selector>	<value>
-example: setInnerText	contentEditable'true	%MSG%
+usage:   setInnerText <wpt-selector> <value>
+example: setInnerText contentEditable'true %MSG%
 
 <wpt-selector> - DOM element to set the innerText of
 <value> - value to use
@@ -354,8 +354,8 @@ For the list of supported selectors, see [Selectors](#selectors).
 Sets the value attribute of the given DOM element to the provided value. This is usually used for filling in text elements on a page (forms or otherwise). Currently only "input" and "textArea" element types are supported.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: setValue	<wpt-selector>	<value>
-example: setValue	name=loginId	userName
+usage:   setValue <wpt-selector> <value>
+example: setValue name=loginId userName
 
 <wpt-selector> - DOM element to set the value of
 <value> - value to use
@@ -367,8 +367,8 @@ For the list of supported selectors, see [Selectors](#selectors).
 Triggers a submit event for the identified form.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: submitForm	<wpt-selector>
-example: submitForm	name=AOLLoginForm
+usage:   submitForm <wpt-selector>
+example: submitForm name=AOLLoginForm
 
 <wpt-selector> - Form element to submit
 ```
@@ -379,16 +379,16 @@ For the list of supported selectors, see [Selectors](#selectors).
 Executes javascript.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: exec	<javascript code>
-example: exec	window.setInterval('window.scrollBy(0,600)', 1000);
+usage:   exec <javascript code>
+example: exec window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
 #### execAndWait
 Executes javascript and waits for the browser to complete any activity generated from the action.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: execAndWait	<javascript code>
-example: execAndWait	window.setInterval('window.scrollBy(0,600)', 1000);
+usage:   execAndWait <javascript code>
+example: execAndWait window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
 ### End Conditions
@@ -400,8 +400,8 @@ Sets the "Activity Based Measurement" mode. The valid values are:
 The default if not specified in the script is 1 (Enabled)
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: setABM	<mode>
-example: setABM	0
+usage:   setABM <mode>
+example: setABM 0
 
 <mode> - ABM mode to use
 ```
@@ -410,8 +410,8 @@ example: setABM	0
 Overrides the timeout value for the time after the last network activity before a test is considered complete (defaults to 2000 which is 2 seconds).
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage: setActivityTimeout	<timeout in milliseconds>
-example: setActivityTimeout	5000
+usage:   setActivityTimeout <timeout in milliseconds>
+example: setActivityTimeout 5000
 
 <timeout in milliseconds> - Number of milliseconds after the last network activity (after onload) before calling a test done.
 ```
@@ -420,8 +420,8 @@ example: setActivityTimeout	5000
 Overrides the timeout value for the individual script steps.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage: setTimeout	<timeout in seconds>
-example: setTimeout	240
+usage:   setTimeout <timeout in seconds>
+example: setTimeout 240
 
 <timeout in seconds> - Number of seconds to allow for the navigation/step to complete.
 ```
@@ -429,8 +429,8 @@ example: setTimeout	240
 #### waitFor
 Poll the page waiting for the supplied script to evaluate to true. Must be set before the navigation step that is to be measured and persists until cleared (by providing an empty script).
 ```markup
-usage: waitFor	<javascript snippet>
-example: waitFor	document.getElementById('results-with-statistics') && document.getElementById('results-with-statistics').innerText.length > 0
+usage:   waitFor <javascript snippet>
+example: waitFor document.getElementById('results-with-statistics') && document.getElementById('results-with-statistics').innerText.length > 0
 
 <javascript snippet> - Code to evaluate periodically to test for complete. Should evaluate to true when the step is to stop.
 ```
@@ -438,8 +438,8 @@ example: waitFor	document.getElementById('results-with-statistics') && document.
 #### waitInterval
 Set the polling interval (in seconds) for the [waitFor](#waitfor) command. Defaults to a 5-second polling interval to minimize overhead.
 ```markup
-usage: waitInterval	<interval in seconds>
-example: waitInterval	1.5
+usage:   waitInterval <interval in seconds>
+example: waitInterval 1.5
 
 <interval in seconds> - Polling interval (in seconds). Supports sub-second values as a float.
 ```
@@ -450,8 +450,8 @@ example: waitInterval	1.5
 Blocks individual requests from loading (useful for blocking content like ads). The command matches the list of things to block against the full url of each request (including host name).
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: block    <block strings>
-example: block    adswrapper.js addthis.com
+usage:   block <block strings>
+example: block adswrapper.js addthis.com
 
 <block strings> - space-delimited list of substrings to block
 ```
@@ -460,8 +460,8 @@ example: block    adswrapper.js addthis.com
 Blocks all requests from the given domains from loading (useful for blocking content like ads). Takes a space-delimited list of full domains to block.
 Browser Support: Desktop (wptdriver 300+)
 ```
-usage: blockDomains    <block domains>
-example: blockDomains    adswrapper.js addthis.com
+usage:   blockDomains <block domains>
+example: blockDomains adswrapper.js addthis.com
 
 <block domains> - space-delimited list of domains to block
 ```
@@ -470,8 +470,8 @@ example: blockDomains    adswrapper.js addthis.com
 Blocks all requests not from one of the given domains from loading (useful for blocking content like ads). Takes a space-delimited list of full domains to allow.
 Browser Support: Desktop (wptdriver 300+)
 ```markup
-usage: blockDomainsExcept    <allow domains>
-example: blockDomainsExcept    www.example.com cdn.example.com
+usage:   blockDomainsExcept <allow domains>
+example: blockDomainsExcept www.example.com cdn.example.com
 
 <allow domains> - space-delimited list of domains to allow
 ```
@@ -480,9 +480,9 @@ example: blockDomainsExcept    www.example.com cdn.example.com
 Stores a browser cookie to be used while navigating.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: setCookie	<path>	<value>
-example: setCookie	http://www.aol.com	zip=20166
-example: setCookie	http://www.aol.com	TestData = Test; expires = Sat,01-Jan-2000 00:00:00 GMT
+usage:   setCookie <path> <value>
+example: setCookie http://www.aol.com zip=20166
+example: setCookie http://www.aol.com TestData = Test; expires = Sat,01-Jan-2000 00:00:00 GMT
 
 <path> - Path where the cookie should be used/stored
 <value> - Cookie value (if expiration information isn't included it will be stored as a session cookie)
@@ -492,8 +492,8 @@ example: setCookie	http://www.aol.com	TestData = Test; expires = Sat,01-Jan-2000
 Allows for overriding the IP address to be used for a host name. The override is effectively the same as populating an entry in the hosts file and will eliminate the DNS lookup times.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage: setDns	<host name>	<IP Address>
-example: setDns	www.aol.com	127.0.0.1
+usage:   setDns <host name> <IP Address>
+example: setDns www.aol.com 127.0.0.1
 
 <host name> - Host name for the DNS entry to override
 <IP Address> - IP Address for the host name to resolve to
@@ -503,8 +503,8 @@ example: setDns	www.aol.com	127.0.0.1
 Allows for overriding a host name (creating a fake CNAME).
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage: setDnsName	<name to override>	<real name>
-example: setDnsName	pat.aol.com	www.aol.com
+usage:   setDnsName <name to override> <real name>
+example: setDnsName pat.aol.com www.aol.com
 
 <name to override> - Host name to replace
 <real name> - Real name to lookup instead
@@ -516,8 +516,8 @@ Browser Support: IE, Chrome, Firefox, Safari
 
 CAUTION : You will still be using the same browser engine so you are still limited by the capabilities and behavior of that browser even if you are spoofing another browser
 ```markup
-usage: setUserAgent    <user agent string>
-example: setUserAgent    Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543 Safari/419.3
+usage:   setUserAgent <user agent string>
+example: setUserAgent Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543 Safari/419.3
 
 <user agent string> - User agent string to use.
 ```
@@ -526,8 +526,8 @@ example: setUserAgent    Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWeb
 Replaces the value of the Host: HTTP header for the given host with the provided replacement.  It also adds a new header (x-Host:) with the original value.
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
 ```markup
-usage: overrideHost	<host>    <new host>
-example: overrideHost	www.aol.com    www.notaol.com
+usage:   overrideHost <host> <new host>
+example: overrideHost www.aol.com www.notaol.com
 
 <host> - host for which you want to override the Host: HTTP header
 <new host> - value to set for the Host header
@@ -537,8 +537,8 @@ example: overrideHost	www.aol.com    www.notaol.com
 For all requests to the given host, rewrite the requests to go to a different server and include the original host in the new URI.
 Browser Support: IE
 ```markup
-usage: overrideHostUrl	<host>    <new host>
-example: overrideHostUrl	www.webpagetest.org    staging.webpagetest.org
+usage:   overrideHostUrl <host> <new host>
+example: overrideHostUrl www.webpagetest.org staging.webpagetest.org
 
 <host> - host for which you want to redirect requests
 <new host> - target server to receive the redirected requests
@@ -549,8 +549,8 @@ In this example, http://www.webpagetest.org/index.php will get rewritten to actu
 Adds the specified header to every http request (in addition to the headers that exist, does not overwrite an existing header).
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
 ```markup
-usage: addHeader	<header>
-example: addHeader	Pragma: akamai-x-cache-on
+usage:   addHeader <header>
+example: addHeader Pragma: akamai-x-cache-on
 
 <header> - Full header entry to add (including label)
 ```
@@ -559,8 +559,8 @@ example: addHeader	Pragma: akamai-x-cache-on
 Adds the specified header to every http request, overriding the header if it already exists.
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
 ```markup
-usage: setHeader	<header>
-example: setHeader	UA-CPU: none-ya
+usage:   setHeader <header>
+example: setHeader UA-CPU: none-ya
 
 <header> - Full header entry to set (including label)
 ```
@@ -569,7 +569,7 @@ example: setHeader	UA-CPU: none-ya
 Clears any headers that were specified through addHeaders or setHeaders (in case you want to only override headers for part of a script).
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage: resetHeaders
+usage:   resetHeaders
 example: resetHeaders
 ```
 
@@ -579,44 +579,49 @@ example: resetHeaders
 Causes multiple script steps to be combined into a single "step" in the results
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage: combineSteps	[count]
+usage:   combineSteps [count]
 example: combineSteps
 
 [count] - Number of script steps to merge (optional, defaults to 0 which is ALL)
 Sample Script:
 
 combineSteps
-navigate	www.google.com
-navigate	www.yahoo.com
-navigate	www.aol.com
+navigate www.google.com
+navigate www.yahoo.com
+navigate www.aol.com
 ```
 
 #### if/else/endif
 Conditionally execute a block of script code based on run number or cached state for the test.  Conditional blocks can be nested.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage:  if	[cached|run]    <value>
-        else
-        endif
+usage:
+if [cached|run] <value>
+<commands>
+else
+<commands>
+endif
 
-example:    if    run    1
-            if    cached    0
-            <do something for first view of first run>
-            endif
-            else
-            <do something else for everything but first run>
-            endif
+example:
+if run 1
+  if cached 0
+  <do something for first view of first run>
+  endif
+else
+  <do something else for everything but first run>
+endif
 
 [cached|run] - Compare against run number or cached state
 <value> - matching run number or cached state to execute block
+<commands> - commands to run
 ```
 
 #### expireCache
 Expires any cache entries that will expire within the specified number of seconds.  This can be used to simulate a repeat view after a certain amount of time (for example, what it would be like to browse the page the next day).  It doesn't help with simulating content changes but any resources with a short expiration will end up being checked with if-modified-since requests.
 Browser Support: IE
 ```markup
-usage: expireCache	<seconds>
-example: expireCache	86400
+usage:   expireCache <seconds>
+example: expireCache 86400
 
 <seconds> - Any resources with a cache lifetime less than this amount of time will be forced to expire.
 ```
@@ -625,11 +630,11 @@ example: expireCache	86400
 Allows you to specify arbitrary preferences that will be configured before launching the browser.
 Browser Support: Firefox
 ```markup
-usage: firefoxPref	<pref>    <value>
+usage:   firefoxPref <pref> <value>
 examples:
-firefoxPref    network.http.pipelining    false
-firefoxPref    network.http.pipelining.maxrequests    5
-firefoxPref    general.useragent.override    "Some User Agent String"
+firefoxPref network.http.pipelining false
+firefoxPref network.http.pipelining.maxrequests 5
+firefoxPref general.useragent.override "Some User Agent String"
 
 <pref> - The preference that is to be modified
 <value> - The value to use.  String values should be enclosed in quotes like the example.
@@ -639,8 +644,8 @@ firefoxPref    general.useragent.override    "Some User Agent String"
 Sets the name of the event for the next measurable operation. It is important to only set this right before the action that will generate the activity you want to measure so that you don't inadvertently measure other page activity. Without explicit event names each step will be automatically named Step_1, Step_2, etc.
 Browser Support: IE
 ```markup
-usage: setEventName	<event name>
-example: setEventName	loadWebmail
+usage:   setEventName <event name>
+example: setEventName loadWebmail
 
 <event name> - Name to use for the event about to occur (in resulting log files)
 ```
@@ -649,8 +654,8 @@ example: setEventName	loadWebmail
 Specifies a geolocation override position.
 Browser Support: Chrome
 ```markup
-usage: setLocation	<lat>,<lng>    <accuracy>
-example: setLocation    38.954980,-77.447956    10
+usage:   setLocation <lat>,<lng> <accuracy>
+example: setLocation 38.954980,-77.447956 10
 
 <lat> - Latitude
 <lng> - Longitude
@@ -661,8 +666,8 @@ example: setLocation    38.954980,-77.447956    10
 Changes the size of the visible browser window so that the page viewport matches the given dimensions.  If you get black areas on your screen shots then the viewport is larger than the desktop.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage: setViewportSize	<width>    <height>
-example: setViewportSize    320    365
+usage:   setViewportSize <width> <height>
+example: setViewportSize 320 365
 
 <width> - Viewport Width
 <height> - Viewport Height
@@ -672,8 +677,8 @@ example: setViewportSize    320    365
 Pauses the script operation for a given number of seconds.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
-usage: sleep	<seconds to sleep>
-example: sleep	5
+usage:   sleep <seconds to sleep>
+example: sleep 5
 
 <seconds to sleep> - An integer indicating how long to sleep.  The allowable range is 1-30.
 ```
@@ -683,66 +688,66 @@ example: sleep	5
 ```markup
 // load the account name and password
 // bring up the login screen
-setEventName	launch
-navigate	http://webmail.aol.com
+setEventName launch
+navigate http://webmail.aol.com
 
 // ignore any errors from here on (in case the mailbox is empty or we get image challenged)
-ignoreErrors	1
+ignoreErrors 1
 
 // log in
-setValue	name=loginId	<username>
-setValue	name=password	<password>
-setEventName	load
-submitForm	name=AOLLoginForm
+setValue name=loginId <username>
+setValue name=password <password>
+setEventName load
+submitForm name=AOLLoginForm
 
 // only read and send a mail once an hour
-minInterval	AOLMail	60
+minInterval AOLMail 60
 
 // close the today curtain
-click	className=backdrop
-sleep	5
+click className=backdrop
+sleep 5
 
 // Open the first message with a subject of "test"
-setEventName	read
-clickAndWait	innerText=test
+setEventName read
+clickAndWait innerText=test
 
 // delete the message
-click	title=Delete (del)
-sleep	5
+click title=Delete (del)
+sleep 5
 
 // open the compose mail form
-setEventName	compose
-clickAndWait	title=Write mail (Alt + w)
+setEventName compose
+clickAndWait title=Write mail (Alt + w)
 
 // send a test message to myself
-sleep	1
-setValue	tabindex=100	<username>
-setValue	name=Subject	test
-loadFile	msg.txt	%MSG%
-setInnerText	contentEditable=true	Some message text
-sleep	1
-setDOMElement	className=confirmMessage
-setEventName	send
-clickAndWait	innerText=Send
+sleep 1
+setValue tabindex=100 <username>
+setValue name=Subject test
+loadFile msg.txt %MSG%
+setInnerText contentEditable=true Some message text
+sleep 1
+setDOMElement className=confirmMessage
+setEventName send
+clickAndWait innerText=Send
 
 endInterval
 
 // sign off
-setEventName	logout
-clickAndWait	className=signOutLink
+setEventName logout
+clickAndWait className=signOutLink
 ```
 
 ### MyAOL Authenticated profile
 ```markup
 // bring up the login screen
-setDOMElement	name=loginId
-navigate	https://my.screenname.aol.com/_cqr/login/login.psp?mcState=initialized&sitedomain=my.aol.com&authLev=0&siteState=OrigUrl%3Dhttp%3A%2F%2Fmy.aol.com%2F
+setDOMElement name=loginId
+navigate https://my.screenname.aol.com/_cqr/login/login.psp?mcState=initialized&sitedomain=my.aol.com&authLev=0&siteState=OrigUrl%3Dhttp%3A%2F%2Fmy.aol.com%2F
 
 // log in
-setValue	name=loginId	<user name>
-setValue	name=password	<password>
-setDOMElement	className=more_pics
-submitForm	name=AOLLoginForm
+setValue name=loginId <user name>
+setValue name=password <password>
+setDOMElement className=more_pics
+submitForm name=AOLLoginForm
 ```
 
 #### DNS Override
@@ -753,10 +758,10 @@ This script will:
 * Set a "zip" cookie on the www.aol.com domain
 * Navigate and measure the time to load www.aol.com
 ```markup
-setDnsName	www1.aol.com	www.aol.com
-setDns	www.aol.com	127.0.0.1
-setCookie	http://www.aol.com	zip=20166
-navigate	http://www.aol.com
+setDnsName www1.aol.com www.aol.com
+setDns www.aol.com 127.0.0.1
+setCookie http://www.aol.com zip=20166
+navigate http://www.aol.com
 ```
 
 #### iPhone Spoofing
@@ -766,7 +771,7 @@ This script will:
 * Change the browser dimensions to match the iPhone
 * Navigate to www.aol.com
 ```markup
-setUserAgent	Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25
-setViewportSize    320    356
-navigate	http://www.aol.com
+setUserAgent Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25
+setViewportSize 320 356
+navigate http://www.aol.com
 ```

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -309,21 +309,6 @@ example: keypress Enter
 
 For the difference between `keypress` and `keypressAndWait`, see [`click`](#click) and [`clickAndWait`](#clickandwait).
 
-#### `sendKeyDown` / `sendKeyUp` / `sendKeyPress` (`sendKeyDownAndWait` / `sendKeyUpAndWait` / `sendKeyPressAndWait`)
-Creates a JavaScript keyboard event (`onkeydown`, `onkeyup`, `onkeypress`) and sends it to the indicated element.
-Browser Support: IE
-```markup
-usage:   sendKeyDownAndWait <wpt-selector> <key>
-example: sendKeyDownAndWait name=user x
-
-<wpt-selector> - DOM element to send the click event to
-<key> - Key command to send (special values are ENTER, DEL, DELETE, BACKSPACE, TAB, ESCAPE, PAGEUP, PAGEDOWN)
-```
-
-For the list of supported selectors, see [Selectors](#selectors).
-
-For the difference between `command` and `commandAndWait` versions, see [`click`](#click) and [`clickAndWait`](#clickandwait).
-
 #### `setInnerHTML`
 Sets the innerHTML of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you want to include HTML formatting.
 Browser Support: IE, Chrome, Firefox
@@ -535,18 +520,6 @@ example: overrideHost www.aol.com www.notaol.com
 <new host> - value to set for the Host header
 ```
 
-#### `overrideHostUrl`
-For all requests to the given host, rewrite the requests to go to a different server and include the original host in the new URI.
-Browser Support: IE
-```markup
-usage:   overrideHostUrl <host> <new host>
-example: overrideHostUrl www.webpagetest.org staging.webpagetest.org
-
-<host> - host for which you want to redirect requests
-<new host> - target server to receive the redirected requests
-```
-In this example, http://www.webpagetest.org/index.php will get rewritten to actually request http://staging.webpagetest.org/www.webpagetest.org/index.php
-
 #### `addHeader`
 Adds the specified header to every http request (in addition to the headers that exist, does not overwrite an existing header).
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
@@ -591,16 +564,6 @@ combineSteps
 navigate www.google.com
 navigate www.yahoo.com
 navigate www.aol.com
-```
-
-#### `expireCache`
-Expires any cache entries that will expire within the specified number of seconds.  This can be used to simulate a repeat view after a certain amount of time (for example, what it would be like to browse the page the next day).  It doesn't help with simulating content changes but any resources with a short expiration will end up being checked with if-modified-since requests.
-Browser Support: IE
-```markup
-usage:   expireCache <seconds>
-example: expireCache 86400
-
-<seconds> - Any resources with a cache lifetime less than this amount of time will be forced to expire.
 ```
 
 #### `clearCache`
@@ -676,71 +639,6 @@ There is currently no way to debug failing WebPageTest scripts. If a script comm
 To simplify script development, consider limiting yourself to [Recommended commands](#recommended-commands) only.
 
 ## Sample scripts
-### Mail test
-```markup
-// load the account name and password
-// bring up the login screen
-setEventName launch
-navigate http://webmail.aol.com
-
-// ignore any errors from here on (in case the mailbox is empty or we get image challenged)
-ignoreErrors 1
-
-// log in
-setValue name=loginId <username>
-setValue name=password <password>
-setEventName load
-submitForm name=AOLLoginForm
-
-// only read and send a mail once an hour
-minInterval AOLMail 60
-
-// close the today curtain
-click className=backdrop
-sleep 5
-
-// Open the first message with a subject of "test"
-setEventName read
-clickAndWait innerText=test
-
-// delete the message
-click title=Delete (del)
-sleep 5
-
-// open the compose mail form
-setEventName compose
-clickAndWait title=Write mail (Alt + w)
-
-// send a test message to myself
-sleep 1
-setValue tabindex=100 <username>
-setValue name=Subject test
-loadFile msg.txt %MSG%
-setInnerText contentEditable=true Some message text
-sleep 1
-setDOMElement className=confirmMessage
-setEventName send
-clickAndWait innerText=Send
-
-endInterval
-
-// sign off
-setEventName logout
-clickAndWait className=signOutLink
-```
-
-### MyAOL Authenticated profile
-```markup
-// bring up the login screen
-setDOMElement name=loginId
-navigate https://my.screenname.aol.com/_cqr/login/login.psp?mcState=initialized&sitedomain=my.aol.com&authLev=0&siteState=OrigUrl%3Dhttp%3A%2F%2Fmy.aol.com%2F
-
-// log in
-setValue name=loginId <user name>
-setValue name=password <password>
-setDOMElement className=more_pics
-submitForm name=AOLLoginForm
-```
 
 ### DNS Override
 This script will:

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -50,7 +50,7 @@ See more [commands](#recommended-commands) and [examples](#sample-scripts) below
 
 For historical reasons, if a script step fails, it does so silently. If something doesn’t work, unfortunately, you won’t get any feedback why. If you’re new to scripting, we recommend using the following commands only. It’s easier to debug them as you can run them manually yourself.
 
-#### navigate
+#### `navigate`
 Navigates the browser to the provided URL and waits for it to complete.
 Browser Support: IE, Chrome, Firefox, Safari
 
@@ -61,7 +61,7 @@ example: navigate http://webmail.aol.com
 <url> - URL to provide the browser for navigation (same as you would enter into the address bar)
 ```
 
-#### exec
+#### `exec`
 Executes javascript.
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -69,7 +69,7 @@ usage:   exec <javascript code>
 example: exec window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
-#### execAndWait
+#### `execAndWait`
 Executes javascript and waits for the browser to complete any activity generated from the action.
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -92,7 +92,7 @@ navigate not-a-comment.com
 
 Commands like [`click`](#click), [`setValue`](#setvalue), and others operate on DOM elements. To select a DOM element, use the following selectors:
 
-#### attribute=value
+#### `<attribute>=<value>`
 
 This selector selects elements based on their HTML attributes. For the following input:
 
@@ -117,7 +117,7 @@ Example:
 setValue type=email darth@vader.com
 ```
 
-#### innerText=text
+#### `innerText=<text>`
 
 This selector selects elements based on its inner text. For the following button:
 
@@ -145,7 +145,7 @@ Example:
 click innerText=Login
 ```
 
-#### innerHtml=html
+#### `innerHtml=<html>`
 
 This selector selects elements based on its inner HTML. For the following link:
 
@@ -177,7 +177,7 @@ click innerHtml=<span>Dashboard</span>
 
 Some variables are replaced based on the URL provided for the test.
 
-#### %URL%
+#### `%URL%`
 
 URL provided for the test.
 
@@ -187,7 +187,7 @@ input: navigate %URL%
 output: navigate  https://wpt.example
 ```
 
-#### %HOST%
+#### `%HOST%`
 
 This will be the Host of the URL provided for the test. This does not include the protocol.
 
@@ -197,7 +197,7 @@ input: setDnsName %HOST% dns.example
 output: setDnsName  wpt.example dns.example
 ```
 
-#### %ORIGIN%
+#### `%ORIGIN%`
 
 The Origin of the URL. This includes the protocol, the host and the port (if it is defined).
 
@@ -211,9 +211,9 @@ input: setCookie  %ORIGIN% foo=bar
 output: setCookie https://wpt.example:8080 foo=bar
 ```
 
-#### %HOSTR%
+#### `%HOSTR%`
 
-Same as [%HOST%](#host) but uses the final host name of the test URL after following any redirects.
+Same as [`%HOST%`](#host) but uses the final host name of the test URL after following any redirects.
 
 ```markup
 URL: https://redirect.wpt.example
@@ -223,7 +223,7 @@ output: setDnsName  wpt.example dns.example
 
 ### Navigation/DOM Interaction
 
-#### navigate
+#### `navigate`
 Navigates the browser to the provided URL and waits for it to complete.
 Browser Support: IE, Chrome, Firefox, Safari
 
@@ -234,8 +234,8 @@ example: navigate http://webmail.aol.com
 <url> - URL to provide the browser for navigation (same as you would enter into the address bar)
 ```
 
-#### click
-Triggers a click event for the identified DOM element. This version does not have an implied wait and the script will continue running after the event is submitted (see [clickAndWait](#clickandwait) for the wait version).
+#### `click`
+Triggers a click event for the identified DOM element. This version does not have an implied wait and the script will continue running after the event is submitted (see [`clickAndWait`](#clickandwait) for the wait version).
 Browser Support: IE, Chrome, Firefox
 ```markup
 usage:   click <wpt-selector>
@@ -246,7 +246,7 @@ example: click title=Delete
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-#### clickAndWait
+#### `clickAndWait`
 Triggers a click event for the identified DOM element and subsequently waits for browser activity to complete.
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -258,7 +258,7 @@ example: clickAndWait innerText=Send
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-#### selectValue
+#### `selectValue`
 Selects a value from a dropdown list of the given DOM element.
 Browser Support: IE
 ```markup
@@ -271,8 +271,8 @@ example: selectValue id=country usa
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-#### sendClick / sendClickAndWait
-Creates a javascript OnClick event and sends it to the indicated element.
+#### `sendClick` / `sendClickAndWait`
+Creates a javascript `onclick` event and sends it to the indicated element.
 Browser Support: IE
 ```markup
 usage:   sendClickAndWait <wpt-selector>
@@ -283,9 +283,9 @@ example: sendClickAndWait innerText=Send
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-For the difference between sendClick and sendClickAndWait, see [click](#click) and [clickAndWait](#clickandwait).
+For the difference between `sendClick` and `sendClickAndWait`, see [`click`](#click) and [`clickAndWait`](#clickandwait).
 
-#### type / typeAndWait
+#### `type` / `typeAndWait`
 Simulate keyboard keypresses for each character in the given string.
 Browser Support: Chrome
 ```markup
@@ -295,9 +295,9 @@ example: type Hello World
 <string> - String of characters to type into the keyboard.
 ```
 
-For the difference between type and typeAndWait, see [click](#click) and [clickAndWait](#clickandwait).
+For the difference between `type` and `typeAndWait`, see [`click`](#click) and [`clickAndWait`](#clickandwait).
 
-#### keypress / keypressAndWait
+#### `keypress` / `keypressAndWait`
 Simulate a keyboard keypress for the given key.
 Browser Support: Chrome
 ```markup
@@ -307,10 +307,10 @@ example: keypress Enter
 <key> - Keyboard key to simulate pressing. Full list of supported keys is [here](https://github.com/WPO-Foundation/wptagent/blob/master/internal/support/keys.json).
 ```
 
-For the difference between keypress and keypressAndWait, see [click](#click) and [clickAndWait](#clickandwait).
+For the difference between `keypress` and `keypressAndWait`, see [`click`](#click) and [`clickAndWait`](#clickandwait).
 
-#### sendKeyDown / sendKeyUp / sendKeyPress (sendKeyDownAndWait / sendKeyUpAndWait / sendKeyPressAndWait)
-Creates a javascript keyboard event (OnKeyDown, OnKeyUp, OnKeyPress) and sends it to the indicated element.
+#### `sendKeyDown` / `sendKeyUp` / `sendKeyPress` (`sendKeyDownAndWait` / `sendKeyUpAndWait` / `sendKeyPressAndWait`)
+Creates a javascript keyboard event (`onkeydown`, `onkeyup`, `onkeypress`) and sends it to the indicated element.
 Browser Support: IE
 ```markup
 usage:   sendKeyDownAndWait <wpt-selector> <key>
@@ -322,9 +322,9 @@ example: sendKeyDownAndWait name=user x
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-For the difference between command and commandAndWait versions, see [click](#click) and [clickAndWait](#clickandwait).
+For the difference between `command` and `commandAndWait` versions, see [`click`](#click) and [`clickAndWait`](#clickandwait).
 
-#### setInnerHTML
+#### `setInnerHTML`
 Sets the innerHTML of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you want to include HTML formatting.
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -337,7 +337,7 @@ example: setInnerHTML contentEditable'true %MSG%
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-#### setInnerText
+#### `setInnerText`
 Sets the innerText of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you don't want to include any HTML formatting.
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -350,8 +350,8 @@ example: setInnerText contentEditable'true %MSG%
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-#### setValue
-Sets the value attribute of the given DOM element to the provided value. This is usually used for filling in text elements on a page (forms or otherwise). Currently only "input" and "textArea" element types are supported.
+#### `setValue`
+Sets the value attribute of the given DOM element to the provided value. This is usually used for filling in text elements on a page (forms or otherwise). Currently only `input` and `textArea` element types are supported.
 Browser Support: IE, Chrome, Firefox
 ```markup
 usage:   setValue <wpt-selector> <value>
@@ -363,8 +363,8 @@ example: setValue name=loginId userName
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-#### submitForm
-Triggers a submit event for the identified form.
+#### `submitForm`
+Triggers a `submit` event for the identified form.
 Browser Support: IE, Chrome, Firefox
 ```markup
 usage:   submitForm <wpt-selector>
@@ -375,7 +375,7 @@ example: submitForm name=AOLLoginForm
 
 For the list of supported selectors, see [Selectors](#selectors).
 
-#### exec
+#### `exec`
 Executes javascript.
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -383,7 +383,7 @@ usage:   exec <javascript code>
 example: exec window.setInterval('window.scrollBy(0,600)', 1000);
 ```
 
-#### execAndWait
+#### `execAndWait`
 Executes javascript and waits for the browser to complete any activity generated from the action.
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -393,7 +393,7 @@ example: execAndWait window.setInterval('window.scrollBy(0,600)', 1000);
 
 ### End Conditions
 
-#### setABM
+#### `setABM`
 Sets the "Activity Based Measurement" mode. The valid values are:
 * 0 - Disabled (Web 1.0 - Measure based off of document complete)
 * 1 - Enabled (Web 2.0 - Measure until activity stops)
@@ -406,7 +406,7 @@ example: setABM 0
 <mode> - ABM mode to use
 ```
 
-#### setActivityTimeout
+#### `setActivityTimeout`
 Overrides the timeout value for the time after the last network activity before a test is considered complete (defaults to 2000 which is 2 seconds).
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
@@ -416,7 +416,7 @@ example: setActivityTimeout 5000
 <timeout in milliseconds> - Number of milliseconds after the last network activity (after onload) before calling a test done.
 ```
 
-#### setTimeout
+#### `setTimeout`
 Overrides the timeout value for the individual script steps.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
@@ -426,7 +426,7 @@ example: setTimeout 240
 <timeout in seconds> - Number of seconds to allow for the navigation/step to complete.
 ```
 
-#### waitFor
+#### `waitFor`
 Poll the page waiting for the supplied script to evaluate to true. Must be set before the navigation step that is to be measured and persists until cleared (by providing an empty script).
 ```markup
 usage:   waitFor <javascript snippet>
@@ -435,8 +435,8 @@ example: waitFor document.getElementById('results-with-statistics') && document.
 <javascript snippet> - Code to evaluate periodically to test for complete. Should evaluate to true when the step is to stop.
 ```
 
-#### waitInterval
-Set the polling interval (in seconds) for the [waitFor](#waitfor) command. Defaults to a 5-second polling interval to minimize overhead.
+#### `waitInterval`
+Set the polling interval (in seconds) for the [`waitFor`](#waitfor) command. Defaults to a 5-second polling interval to minimize overhead.
 ```markup
 usage:   waitInterval <interval in seconds>
 example: waitInterval 1.5
@@ -446,7 +446,7 @@ example: waitInterval 1.5
 
 ### Request Manipulation
 
-#### block
+#### `block`
 Blocks individual requests from loading (useful for blocking content like ads). The command matches the list of things to block against the full url of each request (including host name).
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -456,7 +456,7 @@ example: block adswrapper.js addthis.com
 <block strings> - space-delimited list of substrings to block
 ```
 
-#### blockDomains
+#### `blockDomains`
 Blocks all requests from the given domains from loading (useful for blocking content like ads). Takes a space-delimited list of full domains to block.
 Browser Support: Desktop (wptdriver 300+)
 ```
@@ -466,7 +466,7 @@ example: blockDomains adswrapper.js addthis.com
 <block domains> - space-delimited list of domains to block
 ```
 
-#### blockDomainsExcept
+#### `blockDomainsExcept`
 Blocks all requests not from one of the given domains from loading (useful for blocking content like ads). Takes a space-delimited list of full domains to allow.
 Browser Support: Desktop (wptdriver 300+)
 ```markup
@@ -476,7 +476,7 @@ example: blockDomainsExcept www.example.com cdn.example.com
 <allow domains> - space-delimited list of domains to allow
 ```
 
-#### setCookie
+#### `setCookie`
 Stores a browser cookie to be used while navigating.
 Browser Support: IE, Chrome, Firefox
 ```markup
@@ -488,7 +488,7 @@ example: setCookie http://www.aol.com TestData = Test; expires = Sat,01-Jan-2000
 <value> - Cookie value (if expiration information isn't included it will be stored as a session cookie)
 ```
 
-#### setDns
+#### `setDns`
 Allows for overriding the IP address to be used for a host name. The override is effectively the same as populating an entry in the hosts file and will eliminate the DNS lookup times.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
@@ -499,7 +499,7 @@ example: setDns www.aol.com 127.0.0.1
 <IP Address> - IP Address for the host name to resolve to
 ```
 
-#### setDNSName
+#### `setDNSName`
 Allows for overriding a host name (creating a fake CNAME).
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
@@ -510,7 +510,7 @@ example: setDnsName pat.aol.com www.aol.com
 <real name> - Real name to lookup instead
 ```
 
-#### setUserAgent
+#### `setUserAgent`
 Overrides the User Agent string sent by the browser
 Browser Support: IE, Chrome, Firefox, Safari
 
@@ -522,8 +522,8 @@ example: setUserAgent Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit
 <user agent string> - User agent string to use.
 ```
 
-#### overrideHost
-Replaces the value of the Host: HTTP header for the given host with the provided replacement.  It also adds a new header (x-Host:) with the original value.
+#### `overrideHost`
+Replaces the value of the Host: HTTP header for the given host with the provided replacement.  It also adds a new header (`X-Host:`) with the original value.
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
 ```markup
 usage:   overrideHost <host> <new host>
@@ -533,7 +533,7 @@ example: overrideHost www.aol.com www.notaol.com
 <new host> - value to set for the Host header
 ```
 
-#### overrideHostUrl
+#### `overrideHostUrl`
 For all requests to the given host, rewrite the requests to go to a different server and include the original host in the new URI.
 Browser Support: IE
 ```markup
@@ -545,7 +545,7 @@ example: overrideHostUrl www.webpagetest.org staging.webpagetest.org
 ```
 In this example, http://www.webpagetest.org/index.php will get rewritten to actually request http://staging.webpagetest.org/www.webpagetest.org/index.php
 
-#### addHeader
+#### `addHeader`
 Adds the specified header to every http request (in addition to the headers that exist, does not overwrite an existing header).
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
 ```markup
@@ -555,7 +555,7 @@ example: addHeader Pragma: akamai-x-cache-on
 <header> - Full header entry to add (including label)
 ```
 
-#### setHeader
+#### `setHeader`
 Adds the specified header to every http request, overriding the header if it already exists.
 Browser Support: IE, Chrome, Firefox, Safari (no SSL)
 ```markup
@@ -565,7 +565,7 @@ example: setHeader UA-CPU: none-ya
 <header> - Full header entry to set (including label)
 ```
 
-#### resetHeaders
+#### `resetHeaders`
 Clears any headers that were specified through addHeaders or setHeaders (in case you want to only override headers for part of a script).
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
@@ -575,7 +575,7 @@ example: resetHeaders
 
 ### Misc
 
-#### combineSteps
+#### `combineSteps`
 Causes multiple script steps to be combined into a single "step" in the results
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
@@ -591,7 +591,7 @@ navigate www.yahoo.com
 navigate www.aol.com
 ```
 
-#### if/else/endif
+#### `if`/`else`/`endif`
 Conditionally execute a block of script code based on run number or cached state for the test.  Conditional blocks can be nested.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
@@ -616,7 +616,7 @@ endif
 <commands> - commands to run
 ```
 
-#### expireCache
+#### `expireCache`
 Expires any cache entries that will expire within the specified number of seconds.  This can be used to simulate a repeat view after a certain amount of time (for example, what it would be like to browse the page the next day).  It doesn't help with simulating content changes but any resources with a short expiration will end up being checked with if-modified-since requests.
 Browser Support: IE
 ```markup
@@ -626,7 +626,7 @@ example: expireCache 86400
 <seconds> - Any resources with a cache lifetime less than this amount of time will be forced to expire.
 ```
 
-#### firefoxPref
+#### `firefoxPref`
 Allows you to specify arbitrary preferences that will be configured before launching the browser.
 Browser Support: Firefox
 ```markup
@@ -640,7 +640,7 @@ firefoxPref general.useragent.override "Some User Agent String"
 <value> - The value to use.  String values should be enclosed in quotes like the example.
 ```
 
-#### setEventName
+#### `setEventName`
 Sets the name of the event for the next measurable operation. It is important to only set this right before the action that will generate the activity you want to measure so that you don't inadvertently measure other page activity. Without explicit event names each step will be automatically named Step_1, Step_2, etc.
 Browser Support: IE
 ```markup
@@ -650,7 +650,7 @@ example: setEventName loadWebmail
 <event name> - Name to use for the event about to occur (in resulting log files)
 ```
 
-#### setLocation
+#### `setLocation`
 Specifies a geolocation override position.
 Browser Support: Chrome
 ```markup
@@ -662,7 +662,7 @@ example: setLocation 38.954980,-77.447956 10
 <accuracy> - Accuracy (in meters)
 ```
 
-#### setViewportSize
+#### `setViewportSize`
 Changes the size of the visible browser window so that the page viewport matches the given dimensions.  If you get black areas on your screen shots then the viewport is larger than the desktop.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup
@@ -673,7 +673,7 @@ example: setViewportSize 320 365
 <height> - Viewport Height
 ```
 
-#### sleep
+#### `sleep`
 Pauses the script operation for a given number of seconds.
 Browser Support: IE, Chrome, Firefox, Safari
 ```markup

--- a/src/scripting.md
+++ b/src/scripting.md
@@ -213,7 +213,7 @@ output: setCookie https://wpt.example:8080 foo=bar
 
 #### %HOSTR%
 
-Same as %HOST% but uses the final host name of the test URL after following any redirects.
+Same as [%HOST%](#host) but uses the final host name of the test URL after following any redirects.
 
 ```markup
 URL: https://redirect.wpt.example
@@ -235,47 +235,57 @@ example: navigate	http://webmail.aol.com
 ```
 
 #### click
-Triggers a click event for the identified DOM element. This version does not have an implied wait and the script will continue running after the event is submitted (see clickAndWait for the wait version).
+Triggers a click event for the identified DOM element. This version does not have an implied wait and the script will continue running after the event is submitted (see [clickAndWait](#clickandwait) for the wait version).
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: click	<attribute=value>
-example: click	title=Delete (del)
+usage: click	<wpt-selector>
+example: click	title=Delete
 
-<attribute=value> - DOM element to click on
+<wpt-selector> - DOM element to click on
 ```
+
+For the list of supported selectors, see [Selectors](#selectors).
 
 #### clickAndWait
 Triggers a click event for the identified DOM element and subsequently waits for browser activity to complete.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: clickAndWait	<attribute=value>
+usage: clickAndWait	<wpt-selector>
 example: clickAndWait	innerText=Send
 
-<attribute=value> - DOM element to click on
+<wpt-selector> - DOM element to click on
 ```
+
+For the list of supported selectors, see [Selectors](#selectors).
 
 #### selectValue
 Selects a value from a dropdown list of the given DOM element.
 Browser Support: IE
 ```markup
-usage: selectValue	<attribute=value>	<value>
+usage: selectValue	<wpt-selector>	<value>
 example: selectValue	id=country	usa
 
-<attribute=value> - DOM element to select the value of
+<wpt-selector> - DOM element to select the value of
 <value> - value to use
 ```
+
+For the list of supported selectors, see [Selectors](#selectors).
 
 #### sendClick / sendClickAndWait
 Creates a javascript OnClick event and sends it to the indicated element.
 Browser Support: IE
 ```markup
-usage: sendClickAndWait	<attribute=value>
+usage: sendClickAndWait	<wpt-selector>
 example: sendClickAndWait	innerText=Send
 
-<attribute=value> - DOM element to send the click event to
+<wpt-selector> - DOM element to send the click event to
 ```
 
-#### type (AndWait)
+For the list of supported selectors, see [Selectors](#selectors).
+
+For the difference between sendClick and sendClickAndWait, see [click](#click) and [clickAndWait](#clickandwait).
+
+#### type / typeAndWait
 Simulate keyboard keypresses for each character in the given string.
 Browser Support: Chrome
 ```markup
@@ -285,69 +295,85 @@ example: type Hello World
 <string> - String of characters to type into the keyboard.
 ```
 
-#### keypress (AndWait)
+For the difference between type and typeAndWait, see [click](#click) and [clickAndWait](#clickandwait).
+
+#### keypress / keypressAndWait
 Simulate a keyboard keypress for the given key.
 Browser Support: Chrome
 ```markup
-usage: keypressAndWait <key>
-example: keypressAndWait Enter
+usage: keypress <key>
+example: keypress Enter
 
 <key> - Keyboard key to simulate pressing. Full list of supported keys is [here](https://github.com/WPO-Foundation/wptagent/blob/master/internal/support/keys.json).
 ```
 
-#### sendKeyDown / sendKeyUp / sendKeyPress (AndWait)
+For the difference between keypress and keypressAndWait, see [click](#click) and [clickAndWait](#clickandwait).
+
+#### sendKeyDown / sendKeyUp / sendKeyPress (sendKeyDownAndWait / sendKeyUpAndWait / sendKeyPressAndWait)
 Creates a javascript keyboard event (OnKeyDown, OnKeyUp, OnKeyPress) and sends it to the indicated element.
 Browser Support: IE
 ```markup
-usage: sendKeyDownAndWait	<attribute=value>    <key>
+usage: sendKeyDownAndWait	<wpt-selector>    <key>
 example: sendKeyDownAndWait	name=user    x
 
-<attribute=value> - DOM element to send the click event to
+<wpt-selector> - DOM element to send the click event to
 <key> - Key command to send (special values are ENTER, DEL, DELETE, BACKSPACE, TAB, ESCAPE, PAGEUP, PAGEDOWN)
 ```
+
+For the list of supported selectors, see [Selectors](#selectors).
+
+For the difference between command and commandAndWait versions, see [click](#click) and [clickAndWait](#clickandwait).
 
 #### setInnerHTML
 Sets the innerHTML of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you want to include HTML formatting.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: setInnerHTML	<attribute=value>	<value>
+usage: setInnerHTML	<wpt-selector>	<value>
 example: setInnerHTML	contentEditable'true	%MSG%
 
-<attribute=value> - DOM element to set the innerText of
+<wpt-selector> - DOM element to set the innerText of
 <value> - value to use
 ```
+
+For the list of supported selectors, see [Selectors](#selectors).
 
 #### setInnerText
 Sets the innerText of the given DOM element to the provided value. This is usually used for filling in something like an editable HTML panel (like the message body in webmail). Use this if you don't want to include any HTML formatting.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: setInnerText	<attribute=value>	<value>
+usage: setInnerText	<wpt-selector>	<value>
 example: setInnerText	contentEditable'true	%MSG%
 
-<attribute=value> - DOM element to set the innerText of
+<wpt-selector> - DOM element to set the innerText of
 <value> - value to use
 ```
+
+For the list of supported selectors, see [Selectors](#selectors).
 
 #### setValue
 Sets the value attribute of the given DOM element to the provided value. This is usually used for filling in text elements on a page (forms or otherwise). Currently only "input" and "textArea" element types are supported.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: setValue	<attribute=value>	<value>
+usage: setValue	<wpt-selector>	<value>
 example: setValue	name=loginId	userName
 
-<attribute=value> - DOM element to set the value of
+<wpt-selector> - DOM element to set the value of
 <value> - value to use
 ```
+
+For the list of supported selectors, see [Selectors](#selectors).
 
 #### submitForm
 Triggers a submit event for the identified form.
 Browser Support: IE, Chrome, Firefox
 ```markup
-usage: submitForm	<attribute=value>
+usage: submitForm	<wpt-selector>
 example: submitForm	name=AOLLoginForm
 
-<attribute=value> - Form element to submit
+<wpt-selector> - Form element to submit
 ```
+
+For the list of supported selectors, see [Selectors](#selectors).
 
 #### exec
 Executes javascript.
@@ -410,7 +436,7 @@ example: waitFor	document.getElementById('results-with-statistics') && document.
 ```
 
 #### waitInterval
-Set the polling interval (in seconds) for the waitFor command. Defaults to a 5-second polling interval to minimize overhead.
+Set the polling interval (in seconds) for the [waitFor](#waitfor) command. Defaults to a 5-second polling interval to minimize overhead.
 ```markup
 usage: waitInterval	<interval in seconds>
 example: waitInterval	1.5


### PR DESCRIPTION
TODO:

- [x] Add “Browser support” for `clearCache`

---

Heya,

### What this does

This PR restructures the Scripting doc as follows:
* adds formal sections about the comments syntax and the selectors syntax
* pushes examples to the top of the page (since that’s what most people are jumping to anyway)
* cross-links all sections where appropriate
* normalizes spacing in code blocks (eg spacing in this code snippet looks really weird today ↓) and formatting
   <img width="725" alt="Screen Shot 2022-02-03 at 21 56 15" src="https://user-images.githubusercontent.com/2953267/152410325-531a7f41-034a-44f0-92a2-f2fd99abcb1c.png">

The goal is to make it easier to scan through this doc and find what you need.

I’m comfortable if you decide to amend/reject some of the changes or all of them.

### Why

WebPageTest is great. I’m loving the tool, but it still can be frustrating when you’re trying to write a scripting command, and it just doesn’t work without any clear feedback. Today, I got frustrated by this, went to scripting docs, and ⌘F-ed for “debug” out of despair – only to realize a very useful paragraph about debugging has been sitting in the document this whole time:

> You won't get a lot of feedback as to why a script failed. For debugging purposes it is easiest to limit scripts to navigate and exec/execAndWait commands which can be debugged locally in a browser's dev tools.

What this tells us is nobody (including myself) ever _reads_ docs. From my experience, people tend to scan pages across headings and jump straight to code examples. I took the liberty of restructuring the Scripting doc to make it easier to scan across it.