### PR TITLE
Fix scrolling bug in Chrome 102+

### DIFF
--- a/src/_includes/scripts/in-page-nav.js
+++ b/src/_includes/scripts/in-page-nav.js
@@ -9,7 +9,6 @@ const observer = new IntersectionObserver(entries => {
         const id = entry.target.getAttribute('id')
         const newActive = document.querySelector(`.pageNav a[href="#${id}"]`);
         newActive.classList.add('is-active');
-        newActive.scrollIntoView({ block: 'nearest' });
     }
 }, { rootMargin: `0% 0% -90% 0%` }
 );

--- a/src/_includes/scripts/in-page-nav.js
+++ b/src/_includes/scripts/in-page-nav.js
@@ -9,6 +9,7 @@ const observer = new IntersectionObserver(entries => {
         const id = entry.target.getAttribute('id')
         const newActive = document.querySelector(`.pageNav a[href="#${id}"]`);
         newActive.classList.add('is-active');
+        newActive.closest('.toc').scrollTo(0, newActive.offsetTop);
     }
 }, { rootMargin: `0% 0% -90% 0%` }
 );


### PR DESCRIPTION
😬 Hey y'all, I ran into an issue where I'm unable to read the Getting Started page: https://docs.webpagetest.org/getting-started/

## Problem: scrollIntoView() scrolls the whole document

When I try to scroll down, the IntersectionObserver in `in-page-nav.js` jumps me back to the top of the page:

https://user-images.githubusercontent.com/1619485/175786636-8c70c4d7-2fe8-4488-96dc-9619fcb680a9.mp4

## Solution: Replace scrollIntoView() with scrollTo()

Initially, I quick-fixed the issue by just removing the `scrollIntoView()` call.

But based on https://github.com/WPO-Foundation/webpagetest-docs/pull/25, since the original intent was for this to scroll to each link as its heading comes into view, I've replaced `scrollIntoView()` (which seems to scroll the whole document) with `scrollTo()` (which only scrolls the TOC element).

https://user-images.githubusercontent.com/1619485/175787435-e69d9efc-21da-41f1-950a-c81b37bb05c9.mp4

I also tested on pages with long TOCs (like [Scripting](https://docs.webpagetest.org/scripting/)) and short TOCs (like [Accounts](https://docs.webpagetest.org/accounts/)) or no TOC (like [Custom Metrics Examples](https://docs.webpagetest.org/custom-metrics/examples/)).

To keep the PR as simple as possible, I used `.closest('.toc')` instead of a separate `toc` variable.

🙏 Hopefully this helps.

Let me know if there are any other changes y'all recommend for this update.

> **Note**: Honestly, this bug confuses me, because I'd expect `scrollIntoView()` to only scroll its parent container. But apparently not? I tried reading the spec on [scrolling an element into view](https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view), but couldn't quite understand what determines a "scrolling box". Maybe someone else can explain, or suggest another way to implement this fix?

> **Note**: It seems like this may be a side effect of this Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1318615