### PR TITLE
fix(scripting): more context to exec context id

### DIFF
--- a/src/scripting.md
+++ b/src/scripting.md
@@ -551,7 +551,7 @@ example: setEventName loadWebmail
 <event name> - Name to use for the event about to occur (in resulting log files)
 ```
 #### `setExecutionContext`
-Sets the execution context (main document, iframes, etc) for any subsequent `exec` or `execAndWait` commands to run against. It accepts either the origin or ID of the execution context.
+Sets the execution context (main document, iframes, etc) for any subsequent `exec` or `execAndWait` commands to run against. It accepts either the origin or ID of the execution context (This is not the DOM id. You can find the ID of the execution context in the JSON results of the test).
 
 For example, if you navigate to a URL and there is an iframe that loads content form `https://cdpn.io`, you could have the script run in the iframe context by using the `setExecutionContext`.
 


### PR DESCRIPTION
This can get confusing for a user. Spelling it out a little more clearly.